### PR TITLE
Add tab navigation with dashboard and profile screens

### DIFF
--- a/app/(tabs)/_layout.jsx
+++ b/app/(tabs)/_layout.jsx
@@ -1,0 +1,64 @@
+import { Tabs } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { View, StyleSheet, Platform } from "react-native";
+
+const _Layout = () => {
+    return (
+        <Tabs
+            screenOptions={({ route }) => ({
+                headerShown: false,
+                tabBarShowLabel: true,
+                tabBarStyle: styles.tabBar,
+                tabBarLabelStyle: styles.tabLabel,
+                tabBarActiveTintColor: "#798777",
+                tabBarInactiveTintColor: "#798777",
+                tabBarIcon: ({ focused, color, size }) => {
+                    let iconName;
+
+                    if (route.name === "dashboard") {
+                        iconName = focused ? "home" : "home-outline";
+                    } else if (route.name === "profile") {
+                        iconName = focused ? "person" : "person-outline";
+                    }
+
+                    return (
+                        <View style={styles.iconWrapper}>
+                            <Ionicons name={iconName} size={18} color={"#798777"} />
+                        </View>
+                    );
+                },
+            })}
+        >
+            <Tabs.Screen
+                name="dashboard"
+                options={{
+                    title: "Dashboard",
+                }}
+            />
+            <Tabs.Screen
+                name="profile"
+                options={{
+                    title: "Profile",
+                }}
+            />
+        </Tabs>
+    );
+};
+
+const styles= StyleSheet.create({
+    tabBar: {
+        backgroundColor: "#fff",
+        height: 70,
+        paddingBottom: Platform.OS === "ios" ? 20 : 10,
+    },
+    tabLabel: {
+        fontSize: 10,
+        fontWeight: "600",
+    },
+    iconWrapper: {
+        alignItems: "center",
+        justifyContent: "center",
+    },
+});
+
+export default _Layout;

--- a/app/(tabs)/dashboard.jsx
+++ b/app/(tabs)/dashboard.jsx
@@ -1,0 +1,11 @@
+import { View, Text } from "react-native";
+
+const Dashboard = () => {
+    return (
+        <View className="flex-1 justify-center items-center">
+            <Text className="text-3xl">Dashboard</Text>
+        </View>
+    );
+}
+
+export default Dashboard;

--- a/app/(tabs)/profile.jsx
+++ b/app/(tabs)/profile.jsx
@@ -1,0 +1,11 @@
+import { View, Text } from "react-native";
+
+const Profile = () => {
+    return (
+        <View className="flex-1 justify-center items-center">
+            <Text className="text-3xl">Profile</Text>
+        </View>
+    );
+}
+
+export default Profile;

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -9,6 +9,7 @@ const RootLayout = () => {
         <SafeAreaView className="flex-1">
             <StatusBar style="auto" />
             <Stack>
+              <Stack.Screen name='(tabs)' options={{ title: 'Tabs', headerTitleAlign: 'center', headerShown: false }} />
               <Stack.Screen name='index' options={{ title: 'Homepage', headerTitleAlign: 'center', headerShown: false }} />
             </Stack>
         </SafeAreaView>


### PR DESCRIPTION
Introduced a new tab navigator under (tabs) with Dashboard and Profile screens using Expo Router. Updated the root layout to include the (tabs) stack screen and set its header to be hidden.